### PR TITLE
notify users that RGF has been moved under the roof of the official RGF repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,8 @@
 
 <br>
 
-**UPDATE 17-08-2018**: Now RGF is a part of the [official RGF repository](https://github.com/RGF-team/rgf/tree/master/R-package) and active development is performed there.
+**UPDATE 17-08-2018**: Now RGF is part of the [official RGF repository](https://github.com/RGF-team/rgf/tree/master/R-package) and active development is performed there.
 
-<br>
-<br>
-<br>
-<br>
 <br>
 <br>
 <br>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 [![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/RGF)](http://cran.r-project.org/package=RGF)
 [![Travis-CI Build Status](https://travis-ci.org/mlampros/RGF.svg?branch=master)](https://travis-ci.org/mlampros/RGF)
 [![codecov.io](https://codecov.io/github/mlampros/RGF/coverage.svg?branch=master)](https://codecov.io/github/mlampros/RGF?branch=master)
@@ -6,8 +5,22 @@
 
 
 ## RGF (Regularized Greedy Forest)
+
 <br>
 
+**UPDATE 17-08-2018**: Now RGF is a part of the [official RGF repository](https://github.com/RGF-team/rgf/tree/master/R-package) and active development is performed there.
+
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
 
 The **RGF** package is a wrapper of the [Regularized Greedy Forest (RGF)](https://github.com/RGF-team/rgf_python) *python* package, which also includes a [Multi-core implementation (FastRGF)](https://github.com/baidu/fast_rgf). More details on the functionality of the RGF package can be found in the [blog-post](http://mlampros.github.io/2018/02/14/the_RGF_package/) and in the package Documentation. 
 


### PR DESCRIPTION
This PR updates README with the aim to notify users that this repo has been moved to the official RGF repo. It's better choice than removing the repo, because third-party links to this repo (e.g., blog posts) will not be broken.

@mlampros Also, you can archive this repo to prevent new issues and PRs here. Archive repo looks like this one: https://github.com/baidu/fast_rgf (please note the yellow banner at the top of the screen) and can be performed according to this guide: https://help.github.com/articles/archiving-repositories/